### PR TITLE
Add config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,4 +16,8 @@ install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
 
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ ros2 launch eeg_publisher_cpp mock_publisher_launch.py
 
 To modify the parameters, in the workspace run (for example):
 ```bash
-ros2 run eeg_publisher_cpp mock_publisher_launch.py--ros-args -p num_channels:=32 -p sampling_rate:=1024.0
+ros2 run eeg_publisher_cpp mock_eeg_publisher --ros-args -p num_channels:=32 -p sampling_rate:=1024.0
 ```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ colcon build --packages-select eeg_msgs eeg_publisher_cpp
 source install/setup.bash
 ros2 launch eeg_publisher_cpp mock_publisher_launch.py
 ```
+
+To modify the parameters, in the workspace run (for example):
+```bash
+ros2 run eeg_publisher_cpp mock_publisher_launch.py--ros-args -p num_channels:=32 -p sampling_rate:=1024.0
+```

--- a/config/mock_publisher.yaml
+++ b/config/mock_publisher.yaml
@@ -1,5 +1,5 @@
 mock_eeg_publisher:
   ros__parameters:
-    sampling_rate: 256.0
     num_channels: 8
     num_samples: 32
+    sampling_rate: 256.0

--- a/config/mock_publisher.yaml
+++ b/config/mock_publisher.yaml
@@ -1,0 +1,5 @@
+mock_eeg_publisher:
+  ros__parameters:
+    sampling_rate: 256.0
+    num_channels: 8
+    num_samples: 32

--- a/launch/mock_publisher_launch.py
+++ b/launch/mock_publisher_launch.py
@@ -1,12 +1,14 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     return LaunchDescription([
         Node(
             package='eeg_publisher_cpp',
             executable='mock_eeg_publisher',
             name='mock_eeg_publisher',
+            parameters=["config/mock_publisher.yaml"],
             output='screen'
         ),
     ])

--- a/launch/mock_publisher_launch.py
+++ b/launch/mock_publisher_launch.py
@@ -1,14 +1,22 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+import os
 
 
 def generate_launch_description():
+    config = os.path.join(
+        get_package_share_directory('eeg_publisher_cpp'),
+        'config',
+        'mock_publisher.yaml'
+    )
+
     return LaunchDescription([
         Node(
             package='eeg_publisher_cpp',
             executable='mock_eeg_publisher',
             name='mock_eeg_publisher',
-            parameters=["config/mock_publisher.yaml"],
+            parameters=[config],
             output='screen'
         ),
     ])

--- a/src/mock_eeg_publisher.cpp
+++ b/src/mock_eeg_publisher.cpp
@@ -13,8 +13,8 @@ class MockEEGPublisher : public rclcpp::Node {
 public:
     MockEEGPublisher()
     : Node("mock_eeg_publisher"),
-        num_channels_(declare_parameter<int>("num_channels", 8)),
-        num_samples_(declare_parameter<int>("num_samples", 32)),
+        num_channels_(declare_parameter<int>("num_channels", 1)),
+        num_samples_(declare_parameter<int>("num_samples", 1)),
         sampling_rate_(declare_parameter<double>("sampling_rate", 256.0)),
         rng_(std::random_device{}())
     {

--- a/src/mock_eeg_publisher.cpp
+++ b/src/mock_eeg_publisher.cpp
@@ -13,10 +13,10 @@ class MockEEGPublisher : public rclcpp::Node {
 public:
     MockEEGPublisher()
     : Node("mock_eeg_publisher"),
-      num_channels_(8),
-      num_samples_(32),
-      sampling_rate_(256.0),
-      rng_(std::random_device{}())
+        num_channels_(declare_parameter<int>("num_channels", 8)),
+        num_samples_(declare_parameter<int>("num_samples", 32)),
+        sampling_rate_(declare_parameter<double>("sampling_rate", 256.0)),
+        rng_(std::random_device{}())
     {
         publisher_ = this->create_publisher<eeg_msgs::msg::EEGBlock>("/eeg/raw", 10);
 


### PR DESCRIPTION
This is to test the config file work in mock version. This is working for me, I am working on the similar approach in `sense_acquisition_gtech`. The publisher should show the value in the yaml file instead of the default one.